### PR TITLE
updated to GUI and src

### DIFF
--- a/GUI/MainWindow/runAndWrite.cpp
+++ b/GUI/MainWindow/runAndWrite.cpp
@@ -93,7 +93,7 @@ void MainWindow::openFile(){
     ui->nz->setValue(tmp_list[5].toInt());
 
     double dx = tmp_list[0].toDouble()/(tmp_list[3].toDouble()-1);
-    double dy = tmp_list[1].toDouble()/(tmp_list[2].toDouble()-1);
+    double dy = tmp_list[1].toDouble()/(tmp_list[4].toDouble()-1);
     ui->geometryType->setCurrentIndex(0);
     tmp_list[8].toInt()>0 ? ui->sz->setChecked(true):ui->sz->setChecked(false);
     if (tmp_list.length()>12){
@@ -296,6 +296,8 @@ void MainWindow::openFile(){
         ui->yAbsorbStart->setValue(tmp_list[2].toDouble());
         ui->yAbsorbEnd->setValue(tmp_list[3].toDouble());
 
+    } else {
+        ui->pressureDampingOrRelax->setCurrentIndex(1);
     }
     tmp_line.clear();
     tmp_list.clear();
@@ -329,7 +331,7 @@ void MainWindow::openFile(){
         }
 
     }
-    if ((ui->waveType->currentIndex()==2) & (ui->waveType->currentIndex()==3) )
+    if ((ui->waveType->currentIndex()==2) | (ui->waveType->currentIndex()==3) )
     {
         ui->Hs->setValue(tmp_list[2].toDouble());
         ui->Tp->setValue(tmp_list[1].toDouble());
@@ -546,7 +548,7 @@ void MainWindow::writeInputFile()
         outStream << xAbsorb[0] << " " << xAbsorb[1] << " " << yAbsorb[0] << " " << yAbsorb[1] << " 1 1 0\n";
     } else if ((ui->waveType->currentIndex()==5) & (ui->pressureDampingOrRelax->currentIndex()==1)){ // Only absorbing relaxation zone
         outStream << "1 " << rampTime << " 1 X 0 \n";
-        outStream << xAbsorb[0] << " " << xAbsorb[1] << " " << yAbsorb[0] << " " << yAbsorb[1] << " 1 9 3.5 X 0 X 0 \n";
+        outStream << xAbsorb[0] << " " << xAbsorb[1] << " " << yAbsorb[0] << " " << yAbsorb[1] << " 9 3.5 X 0 X 0 \n";
         outStream << "0 0\n";
     } else if ((ui->waveType->currentIndex()!=5) & (ui->pressureDampingOrRelax->currentIndex()==0)) {
         outStream << "1 " << rampTime << " 1 X 0 \n";

--- a/GUI/MainWindow/waveGeneration.cpp
+++ b/GUI/MainWindow/waveGeneration.cpp
@@ -8,7 +8,7 @@ void MainWindow::on_waveTheoryChanged()
 
 void MainWindow::on_waveTheoryChanged(int waveTheory)
 {
-    if (waveTheory==1) {
+    if (waveTheory==1) { // stream function waves
         ui->widget_SF->setVisible(true);ui->LorP_ComboBox->setVisible(true);
 
         if (ui->LorP_ComboBox->currentIndex()==0){
@@ -23,18 +23,22 @@ void MainWindow::on_waveTheoryChanged(int waveTheory)
         ui->widget_waveFile->setVisible(false);
         ui->waveGeneration_widget->setEnabled(true);
         ui->widget_customSpectrum->setVisible(false);
-    } else if (waveTheory==2){
+    } else if (waveTheory==2){ // JONSWAP
         ui->widget_SF->setVisible(false);ui->LorP_ComboBox->setVisible(false);
         ui->widget_JONSWAP->setVisible(true);
         ui->widget_waveFile->setVisible(false);
         ui->waveGeneration_widget->setEnabled(true);
         ui->widget_customSpectrum->setVisible(false);
+        ui->gamma_jonswap->setVisible(true);
+        ui->gamma_jonswap_label->setVisible(true);
     } else if (waveTheory==3){
         ui->widget_JONSWAP->setVisible(true);
         ui->widget_SF->setVisible(false);
         ui->widget_waveFile->setVisible(false);
         ui->waveGeneration_widget->setEnabled(true);
         ui->widget_customSpectrum->setVisible(false);
+        ui->gamma_jonswap->setVisible(false);
+        ui->gamma_jonswap_label->setVisible(false);
     } else if (waveTheory==4) {
         ui->widget_customSpectrum->setVisible(true);
         ui->widget_waveFile->setVisible(false);

--- a/GUI/customgrid.cpp
+++ b/GUI/customgrid.cpp
@@ -145,15 +145,16 @@ if (x<=xData.first()){
     h = zData.last();
 } else {
     for (int i=0;i<zData.size()-1;i++){
+
         if ((xData[i+1]>x)&(xData[i]<x)){
             h = (zData[i+1]-zData[i])/(xData[i+1]-xData[i])*(x-xData[i])+zData[i];
         } else if (xData[i+1]==x){
-            h = xData[i+1];
+            h = zData[i+1];
 
         }
-
     }
 }
+
     return h;
 }
 

--- a/GUI/mainwindow.h
+++ b/GUI/mainwindow.h
@@ -100,6 +100,7 @@ private:
     double Tp;
     double h;
     double gamma;
+    double gamma_jonswap;
     double khmax;
     int SF_n;
     int LorT;

--- a/GUI/mainwindow.ui
+++ b/GUI/mainwindow.ui
@@ -499,7 +499,7 @@
        <enum>QTabWidget::Rounded</enum>
       </property>
       <property name="currentIndex">
-       <number>2</number>
+       <number>0</number>
       </property>
       <widget class="QWidget" name="tab_11">
        <attribute name="title">
@@ -1647,6 +1647,9 @@
            <height>24</height>
           </rect>
          </property>
+         <property name="decimals">
+          <number>3</number>
+         </property>
          <property name="maximum">
           <double>10000.000000000000000</double>
          </property>
@@ -2254,6 +2257,9 @@
            <height>24</height>
           </rect>
          </property>
+         <property name="decimals">
+          <number>3</number>
+         </property>
          <property name="maximum">
           <double>9999.000000000000000</double>
          </property>
@@ -2784,7 +2790,7 @@
         <property name="geometry">
          <rect>
           <x>30</x>
-          <y>90</y>
+          <y>110</y>
           <width>711</width>
           <height>80</height>
          </rect>
@@ -3025,6 +3031,38 @@
          </property>
          <property name="maximum">
           <number>5</number>
+         </property>
+        </widget>
+        <widget class="QDoubleSpinBox" name="gamma_jonswap">
+         <property name="geometry">
+          <rect>
+           <x>480</x>
+           <y>30</y>
+           <width>62</width>
+           <height>23</height>
+          </rect>
+         </property>
+         <property name="maximum">
+          <double>10.000000000000000</double>
+         </property>
+         <property name="singleStep">
+          <double>0.100000000000000</double>
+         </property>
+         <property name="value">
+          <double>3.300000000000000</double>
+         </property>
+        </widget>
+        <widget class="QLabel" name="gamma_jonswap_label">
+         <property name="geometry">
+          <rect>
+           <x>480</x>
+           <y>10</y>
+           <width>54</width>
+           <height>15</height>
+          </rect>
+         </property>
+         <property name="text">
+          <string>gamma</string>
          </property>
         </widget>
        </widget>

--- a/GUI/mainwindow.ui
+++ b/GUI/mainwindow.ui
@@ -499,7 +499,7 @@
        <enum>QTabWidget::Rounded</enum>
       </property>
       <property name="currentIndex">
-       <number>0</number>
+       <number>2</number>
       </property>
       <widget class="QWidget" name="tab_11">
        <attribute name="title">
@@ -654,7 +654,7 @@
          </rect>
         </property>
         <property name="text">
-         <string>Open</string>
+         <string>Change</string>
         </property>
        </widget>
        <widget class="QLineEdit" name="workingDir">

--- a/common.mk
+++ b/common.mk
@@ -5,7 +5,7 @@
 
 # Program name
 PROGNAME = OceanWave3D
-LIBNAME  = libOceanWave3D.so
+LIBNAME  = libOceanWave3D_botp.so
 
 # Installation directory
 INSTALLDIR = $(HOME)/bin
@@ -23,7 +23,7 @@ BUILDDIR = $(PWD)/build
 #FC = gfortran-4.4
 #FC = gf90
 
-USER = hbb
+USER = botp-dev
 
 # First the blocks based on compiler name:  
 

--- a/src/IO/ReadInputFileParameters.f90
+++ b/src/IO/ReadInputFileParameters.f90
@@ -444,25 +444,23 @@ SUBROUTINE ReadInputFileParameters
 	! To have a clean interface without too many goto statement,we first check what type we are trying to read
 	
 		READ(FILEIP(1),*,IOSTAT=ios) ispec
-		
+		Backspace(FILEIP(1)) 
+		print *, 'dsfasdfasdf ', ispec
 		IF (ispec==0 .or. ispec==1) THEN !Normal PM or JONSWAP spectrum
-			Backspace(FILEIP(1)) 
 	        READ(FILEIP(1),*,IOSTAT=ios) ispec,  Tp,  Hs,  h0,   &
 					kh_max,  seed,  seed2,  x0,  y0
 					gamma_jonswap = 3.3
 	
-		ELSEIF (ispec == 2) THEN!  2D irregular waves with input file
+		ELSEIF (ispec == 2) THEN ! 2D irregular waves with input file
 			READ(FILEIP(1),*,IOSTAT=ios) ispec,  Tp,  Hs,  h0,   & 
 					kh_max,  seed,  seed2,  x0,  y0, &
 					inc_wave_file
-					
+					print *, x0, y0, inc_wave_file
 		ELSEIF (ispec == 3) THEN ! 2D irregular waves with non-standard gamma value
-			Backspace(FILEIP(1)) 
 			READ(FILEIP(1),*,IOSTAT=ios) ispec,  Tp,  Hs,  h0,   &
 	                    kh_max,  seed,  seed2,  x0,  y0, gamma_jonswap
 	                  
 		ELSEIF (ispec>=30) THEN ! multi-directional irregular waves
-			Backspace(FILEIP(1))  
 			READ(FILEIP(1),*,ERR=37,END=37,IOSTAT=ios) ispec,  Tp,  Hs,  h0,   & 
 	            kh_max,  seed,  seed2,  x0,  y0, &
 	            inc_wave_file, beta0, s0

--- a/src/IO/ReadInputFileParameters.f90
+++ b/src/IO/ReadInputFileParameters.f90
@@ -12,7 +12,7 @@ SUBROUTINE ReadInputFileParameters
   IMPLICIT NONE
   INTEGER ios, i, nxIC, nyIC, iflag_phi, ispec, nGenZones
   REAL(kind=long) :: xtankIC, ytankIC, t0IC, Tp, Hs, h0, kh_max, seed, seed2, x0, &
-       y0, beta0, s0
+       y0, beta0, s0, gamma_jonswap
   CHARACTER(len=30):: inc_wave_file
 
   READ (FILEIP(1),'(A)',ERR=100,IOSTAT=ios) HEAD(1)
@@ -425,38 +425,65 @@ SUBROUTINE ReadInputFileParameters
 ! Linear mono-chromatic or random wave generation parameters.  
 ! 
 
-  IF (IncWaveType==3) THEN 
-      ! Wave generation with flux condition on western boundary
-      READ(FILEIP(1),*,ERR=34,END=34) wave3DFlux%rampTime, wave3DFlux%order, wave3DFlux%inc_wave_file
-      Go To 35
-34     Print *, 'ReadInputFileParameters:  For IncWaveType==3 we need: Ramp &
-time, Order of interpolation in horizontal direction, file with wave paddle signal.'
-35    continue
-  ELSE
-      READ(FILEIP(1),*,ERR=31,END=31) ispec,  Tp,  Hs,  h0,   &
-            kh_max,  seed,  seed2,  x0,  y0, &
-            inc_wave_file, beta0, s0
-      Go To 33
-31    Backspace(FILEIP(1)) 
-      READ(FILEIP(1),*,ERR=32,END=32) ispec,  Tp,  Hs,  h0,   &
-            kh_max,  seed,  seed2,  x0,  y0, &
-            inc_wave_file
-      If( abs(ispec)<30 ) Then
-          beta0=0
-          s0=1.0
-      ELSE
-         Print *, 'ReadInputFileParameters:  For 3D waves, abs(ispec)>30, we need a heading angle and a spreading factor.'
-         STOP
-      END If
-      Go To 33
+	IF (IncWaveType==3) THEN 
+		! Wave generation with flux condition on western boundary
+		READ(FILEIP(1),*,IOSTAT=ios) wave3DFlux%rampTime, wave3DFlux%order, wave3DFlux%inc_wave_file
+		IF (ios>0) THEN
+     		Print *, 'ReadInputFileParameters:  For IncWaveType==3 we need: Ramp &
+				time, Order of interpolation in horizontal direction, file with wave paddle signal.'
+			stop
+		END IF
 
-32    IF(IncWaveType==2)THEN
-         Print *, 'ReadInputFileParameters:  For IncWaveType==2 we need irregular wave parameters.'
-         Stop
-      END IF
+	ELSEIF (IncWaveType == 2) THEN ! irregular waves
+	! For irregular waves we have four options: 
+	! 0) PM, 
+	! 1) Normal JONSWAP with gamma = 3.3, 
+	! 2) based on input files and 
+	! 3) JONSWAP with variable gamma value
+	!
+	! To have a clean interface without too many goto statement,we first check what type we are trying to read
+	
+		READ(FILEIP(1),*,IOSTAT=ios) ispec
+		
+		IF (ispec==0 .or. ispec==1) THEN !Normal PM or JONSWAP spectrum
+			Backspace(FILEIP(1)) 
+	        READ(FILEIP(1),*,IOSTAT=ios) ispec,  Tp,  Hs,  h0,   &
+					kh_max,  seed,  seed2,  x0,  y0
+					gamma_jonswap = 3.3
+	
+		ELSEIF (ispec == 2) THEN!  2D irregular waves with input file
+			READ(FILEIP(1),*,IOSTAT=ios) ispec,  Tp,  Hs,  h0,   & 
+					kh_max,  seed,  seed2,  x0,  y0, &
+					inc_wave_file
+					
+		ELSEIF (ispec == 3) THEN ! 2D irregular waves with non-standard gamma value
+			Backspace(FILEIP(1)) 
+			READ(FILEIP(1),*,IOSTAT=ios) ispec,  Tp,  Hs,  h0,   &
+	                    kh_max,  seed,  seed2,  x0,  y0, gamma_jonswap
+	                  
+		ELSEIF (ispec>=30) THEN ! multi-directional irregular waves
+			Backspace(FILEIP(1))  
+			READ(FILEIP(1),*,ERR=37,END=37,IOSTAT=ios) ispec,  Tp,  Hs,  h0,   & 
+	            kh_max,  seed,  seed2,  x0,  y0, &
+	            inc_wave_file, beta0, s0
+	            
+	    END IF
+		
+		IF( abs(ispec)<30 ) THEN
+				beta0=0
+				s0=1.0
+		END IF
+	
+37	    IF(ios>0)THEN
+			IF (abs(ispec)<30) THEN
+				Print *, 'ReadInputFileParameters:  For IncWaveType==2 we need irregular wave parameters.'
+			ELSE
+					Print *, 'ReadInputFileParameters:  For 3D waves, abs(ispec)>30, we need a heading angle and a spreading factor.'
+			END IF
+			STOP
+		END IF
+	END IF
 
-33     Continue
-  ENDIF
   !
   !
   IF (relaxONOFF==1) THEN ! GD: add this test in case of no relaxation zones defined
@@ -475,6 +502,7 @@ time, Order of interpolation in horizontal direction, file with wave paddle sign
            RandomWave(i)%seed=seed; RandomWave(i)%seed2=seed2; RandomWave(i)%kh_max=kh_max;
            RandomWave(i)%inc_wave_file=inc_wave_file; RandomWave(i)%beta0=beta0; 
            RandomWave(i)%S0=s0
+           RandomWave(i)%gamma = gamma_jonswap
            If(RelaxZones(i)%XorYgen=='X' .AND. RelaxZones(i)%WavegenONOFF==1) THEN
               nGenZones=nGenZones+1
               If( abs(RandomWave(i)%ispec) >= 30 .and. RelaxZones(i)%degrees /= 0) THEN

--- a/src/IO/ReadInputFileParameters.f90
+++ b/src/IO/ReadInputFileParameters.f90
@@ -445,7 +445,6 @@ SUBROUTINE ReadInputFileParameters
 	
 		READ(FILEIP(1),*,IOSTAT=ios) ispec
 		Backspace(FILEIP(1)) 
-		print *, 'dsfasdfasdf ', ispec
 		IF (ispec==0 .or. ispec==1) THEN !Normal PM or JONSWAP spectrum
 	        READ(FILEIP(1),*,IOSTAT=ios) ispec,  Tp,  Hs,  h0,   &
 					kh_max,  seed,  seed2,  x0,  y0

--- a/src/main/OceanWave3DT0Setup.f90
+++ b/src/main/OceanWave3DT0Setup.f90
@@ -102,10 +102,10 @@ SUBROUTINE OceanWave3DT0Setup
            WRITE(6,71)RandomWave(1)%Tp,RandomWave(1)%Hs,RandomWave(1)%seed,RandomWave(1)%seed2
 71         FORMAT(' The incident wave is a 2D P-M spectrum with',/,&
                 ' T_p=', e10.4,' and H_s=',e10.4,', seed values are:',/,2i10,//)
-        ELSEIF(RandomWave(1)%ispec==1)THEN
-           WRITE(6,72)RandomWave(1)%Tp,RandomWave(1)%Hs,RandomWave(1)%seed,RandomWave(1)%seed2
+        ELSEIF(RandomWave(1)%ispec==1 .or. RandomWave(1)%ispec==3)THEN
+           WRITE(6,72)RandomWave(1)%Tp,RandomWave(1)%Hs,RandomWave(1)%gamma,RandomWave(1)%seed,RandomWave(1)%seed2
 72         FORMAT(' The incident wave is a 2D JONSWAP spectrum with ',/, &
-                'T_p=',  e10.4,' and H_s=',e10.4,', seed values are:',/,2i10,//)
+                'T_p=',  e10.4,', H_s=',e10.4,' and gamma=',e10.4, ' and seed values are:',/,2i10,//)
         ELSEIF(RandomWave(1)%ispec==2)THEN
            WRITE(6,73)RandomWave(1)%inc_wave_file
 73         FORMAT(' The incident wave will be read from file ',a30,/)
@@ -184,7 +184,7 @@ SUBROUTINE OceanWave3DT0Setup
         Call random_wave_coefficients( RandomWave(i)%ispec, n_fft, RandomWave(i)%beta0, &
              dt, dx, RandomWave(i)%Tp, RandomWave(i)%Hs, RandomWave(i)%h0, g,              &
              RandomWave(i)%inc_wave_file, RandomWave(i)%kh_max, RandomWave(i)%seed,  &
-             RandomWave(i)%seed2, RandomWave(1)%eta0, RandomWave(1)%beta, RandomWave(1)%S0, n_cut )
+             RandomWave(i)%seed2, RandomWave(1)%eta0, RandomWave(1)%beta, RandomWave(1)%S0, n_cut,RandomWave(i)%gamma )
         !
         ! Count the total number of grid points in each generation zone and allocate space
         ! for eta and phiS and compute the elevation and surface potential time-histories.  

--- a/src/utilities/JONSWAP_spectrum.f90
+++ b/src/utilities/JONSWAP_spectrum.f90
@@ -1,4 +1,4 @@
- FUNCTION JONSWAP_spectrum(FREQ, Hs, Tp)
+ FUNCTION JONSWAP_spectrum(FREQ, Hs, Tp,gamma)
 !
 ! This function returns the value of the JONSWAP spectrum
 ! for the frequency FREQ, significant wave height Hs, and peak period
@@ -11,7 +11,6 @@
         two=2._long, half=.5_long, five=5._long, grav=9.82_long
    pi = acos (-one)
    f_p=one/Tp
-   gamma=3.3_long
    alpha=3.32285_long * Hs**2 * f_p**4
    A=alpha*grav**2/(two*pi)**4
    B=five/four * f_p**4

--- a/src/utilities/build_coeff.f90
+++ b/src/utilities/build_coeff.f90
@@ -1,4 +1,4 @@
- SUBROUTINE build_coeff (ETA, N, Hs, Tp, DELT, SEED, seed2, i_spec)
+ SUBROUTINE build_coeff (ETA, N, Hs, Tp, DELT, SEED, seed2, i_spec,gamma)
 !
 ! This subroutine returns Z(w), the Fourier transform of
 ! the wave elevation, zeta(t).  The coefficients are based on
@@ -11,7 +11,7 @@
    REAL(kind=long) :: Hs, Tp, pi, delt, df, cst, freq, spec,           &
         pm_spectrum, jonswap_spectrum, zero=0._long,          &
         one=1._long, two=2._long, four=4._long, half=.5_long,          &
-        twopi, ran1, psi, mag
+        twopi, ran1, psi, mag, gamma
    REAL(kind=long) :: ETA(n) ! GD : modif so that types are compatible... n has to be a power of 2
    COMPLEX(kind=long) :: phase
    EXTERNAL gasdev, ran1_b, pm_spectrum, jonswap_spectrum
@@ -49,7 +49,7 @@
       IF(i_spec==0)THEN
          spec= pm_spectrum(freq, Hs, Tp)
       ELSE
-         spec= jonswap_spectrum(freq, Hs, Tp)
+         spec= jonswap_spectrum(freq, Hs, Tp,gamma)
       ENDIF
 
       write(78,*)freq,1/freq,spec

--- a/src/utilities/random_wave_coefficients.f90
+++ b/src/utilities/random_wave_coefficients.f90
@@ -1,5 +1,6 @@
 SUBROUTINE random_wave_coefficients(i_spec, nt, beta0, dt, dx, Tp, Hs, depth, &
-     grav, inc_wave_file, kh_max, seed, seed2, eta0, beta, s0, n_cut)
+     grav, inc_wave_file, kh_max, seed, seed2, eta0, beta, s0, &
+     n_cut,gamma_jonswap)
   !-----------------------------------------------------------------------
   !
   ! Build the coefficients for a pseudo-random 3D wave with direction BETA0 to the 
@@ -18,7 +19,7 @@ SUBROUTINE random_wave_coefficients(i_spec, nt, beta0, dt, dx, Tp, Hs, depth, &
   CHARACTER(len=30) inc_wave_file, header
   integer, parameter :: long=selected_real_kind(12,99)
   integer i, i_spec, seed, seed2, nt, n_cut
-  real(kind=long) :: Tp, Hs, dt, depth, grav, kh_max, dx, s0
+  real(kind=long) :: Tp, Hs, dt, depth, grav, kh_max, dx, s0, gamma_jonswap
   real(kind=long) :: eta0(nt), beta(nt)
 
   ! Local variables
@@ -54,9 +55,9 @@ SUBROUTINE random_wave_coefficients(i_spec, nt, beta0, dt, dx, Tp, Hs, depth, &
   IF(i_spec==0 .or. i_spec==30)THEN 
      ! A long-crested P-M spectrum
      CALL build_coeff(eta0, nt, Hs, Tp, dt, seed, seed2, 0)
-  ELSEIf(i_spec==1 .or. i_spec==31)THEN
+  ELSEIf(i_spec==1 .or. i_spec==31 .or. i_spec==3)THEN
      ! A long-crested JONSWAP spectrum
-     CALL build_coeff(eta0, nt, Hs, Tp, dt, seed, seed2, 1)
+     CALL build_coeff(eta0, nt, Hs, Tp, dt, seed, seed2, 1,gamma_jonswap)
   ELSEIF(i_spec==33)THEN
      ! A JONSWAP spectrum with a normal spreading
      CALL build_coeff_3D(eta0, beta, nt, Hs, Tp, dt, seed, seed2, beta0)

--- a/src/variabledefs/datatypes.f90
+++ b/src/variabledefs/datatypes.f90
@@ -146,7 +146,7 @@ END TYPE SFparam
 ! DEFINE a Structure for random and mono-chromatic wave generation parameters
 
 TYPE RandomWaveParam
-	REAL(KIND=long) :: Tp, Hs, h0, kh_max, dx, x0, y0, beta0, S0
+	REAL(KIND=long) :: Tp, Hs, h0, kh_max, dx, x0, y0, beta0, S0, gamma
 	INTEGER :: ispec, seed, seed2, nf, nx, ny
         CHARACTER(len=30)  inc_wave_file
         REAL(KIND=long), allocatable :: eta(:,:), Phis(:,:), eta0(:), Phis0(:), beta(:)


### PR DESCRIPTION
Hej Allan,

Jeg har lavet foelgende updates til OceanWave3D:

src: 
*) Additional irregular wave type (ispec=3) is added. Users can now specify gamma (peak enhancement factor) for the spectrum. Old input files (ispec={0,1,2}) are still supported
*) I cleaned up the last part of the "ReadInputFilesParameters.f90" and replaced most "GO TO" statements with IF sentences, since they are easier to read and less error prone.   

GUI:
*) Important bug-fix for generation of random irregular (JONSWAP) waves:  seed values are changed from a positive to a negative number as required by "ran_1b". 
*) Small bug-fixes for 3D domains
*) Gamma value for JONSWAP waves added to interface and to IO functions

/Bo
